### PR TITLE
fix(portability): 消除硬编码本机路径 + j-skills 失效链清理指引

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ j-skills uninstall <name> -g  # 卸载
 
 ## 路径信息
 
-- **本项目路径**: `/Users/jiashengwang/jacky-github/jacky-skills`
+- **本项目路径**: `~/jacky-github/jacky-skills`
 - **全局 Skills 目录**: `~/.claude/skills/`
 
 ## 快速参考

--- a/archived/multi-agent/README.md
+++ b/archived/multi-agent/README.md
@@ -14,7 +14,7 @@
 
 ```bash
 # 方式 1：链接到全局（开发模式）
-cd /Users/jiashengwang/jacky-github/jacky-skills
+cd ~/jacky-github/jacky-skills
 j-skills link multi-agent
 
 # 方式 2：安装到全局

--- a/docs/skill-system-guide-cloudflare部署记录.md
+++ b/docs/skill-system-guide-cloudflare部署记录.md
@@ -3,7 +3,7 @@
 > 一句话：把 `docs/skill-system-guide.html` 这一个静态 HTML，用 Cloudflare 官方 CLI `wrangler` 一条命令发布成公网可访问的网页，并记录用到的 CLI 工具与可借鉴的 Skills。
 
 - **部署日期**：2026-06-22
-- **被部署文件**：`/Users/jiashengwang/jacky-github/jacky-skills/docs/skill-system-guide.html`（34.2 KB，自包含单文件，无本地外链）
+- **被部署文件**：`~/jacky-github/jacky-skills/docs/skill-system-guide.html`（34.2 KB，自包含单文件，无本地外链）
 - **页面标题**：工程开发 Skill 流水线 + 沉淀底座
 - **托管方式**：Cloudflare Pages（Direct Upload，非 Git 集成）
 - **Cloudflare 账号**：`2409277719@qq.com`（Account ID `6388c4205d34261a324d0bf02a6f0584`）

--- a/plugins/dev-tools/.claude-plugin/plugin.json
+++ b/plugins/dev-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-tools",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "核心开发工具集 - 任务工作流、发布工具、效率审计",
   "author": {
     "name": "Jacky Wang",

--- a/plugins/dev-tools/todo/references/setup-guide.md
+++ b/plugins/dev-tools/todo/references/setup-guide.md
@@ -6,7 +6,7 @@
 
 ```bash
 # 链接到全局
-cd /Users/jiashengwang/jacky-github/jacky-skills
+cd ~/jacky-github/jacky-skills
 j-skills link todo
 
 # 安装到全局

--- a/plugins/dev-tools/todo/tests/verify.sh
+++ b/plugins/dev-tools/todo/tests/verify.sh
@@ -23,7 +23,8 @@ else
   TEST_DIR="/tmp/todo-skill-verify-$$"
 fi
 
-SKILL_DIR="/Users/jiashengwang/jacky-github/jacky-skills/plugins/dev-tools/todo"
+# 从脚本自身位置推导（tests/ 的上级即 skill 根目录），不硬编码绝对路径
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 assert() {
   local desc="$1"

--- a/plugins/learning-tools/.claude-plugin/plugin.json
+++ b/plugins/learning-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-tools",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "学习工具集 - 仓库学习、文档本地化与调研分析",
   "author": {
     "name": "Jacky Wang",

--- a/plugins/learning-tools/learn-repo/SKILL.md
+++ b/plugins/learning-tools/learn-repo/SKILL.md
@@ -129,7 +129,7 @@ recall / resume / 学习日志
 - **可追溯**：记录学习时所基于的 commit，日后源码演进了，笔记里的 file:line 仍能对照 source/ 快照
 - **可并存**：同一 GitHub 项目目录下多个 `*-study` 互不干扰，resume 时统一扫描
 
-> 全文出现的 `{study目录}` 均指 `{GitHub 项目目录}/{repo-name}-study/`。`{GitHub 项目目录}` 从 CLAUDE.md 配置读取（如 `/Users/jiashengwang/jacky-github`），不要硬编码。
+> 全文出现的 `{study目录}` 均指 `{GitHub 项目目录}/{repo-name}-study/`。`{GitHub 项目目录}` 从 CLAUDE.md 配置读取（如 `~/jacky-github`），不要硬编码。
 
 ## 整体流程
 

--- a/plugins/learning-tools/repo-study/SKILL.md
+++ b/plugins/learning-tools/repo-study/SKILL.md
@@ -477,7 +477,7 @@ explorer/
 
 当用户使用 `/repo-study list` 时：
 
-1. 读取 CLAUDE.md 中的 `GitHub 项目目录` 配置（如 `/Users/jiashengwang/jacky-github`）
+1. 读取 CLAUDE.md 中的 `GitHub 项目目录` 配置（如 `~/jacky-github`）
 2. 扫描该目录下所有匹配 `*-study` 的子目录
 3. 对每个 study 目录，尝试读取 `.study-meta.json` 获取元数据
 4. 输出表格：

--- a/plugins/learning-tools/repo-study/scripts/repo-study-sync-ob.sh
+++ b/plugins/learning-tools/repo-study/scripts/repo-study-sync-ob.sh
@@ -16,8 +16,8 @@
 set -euo pipefail
 
 # ============ 配置 ============
-OB_VAULT="/Users/jiashengwang/jacky-github/jacky-obsidian"
-STUDY_BASE="/Users/jiashengwang/jacky-github"
+OB_VAULT="${OB_VAULT:-$HOME/jacky-github/jacky-obsidian}"
+STUDY_BASE="${STUDY_BASE:-$HOME/jacky-github}"
 OB_OPEN_SOURCE="$OB_VAULT/wiki/open-source"
 
 # ============ 参数解析 ============

--- a/plugins/monitoring/.claude-plugin/plugin.json
+++ b/plugins/monitoring/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monitoring",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Claude Code 监控工具集 - macOS 原生悬浮窗通知、工作记录查看",
   "author": {
     "name": "Jacky Wang",

--- a/plugins/monitoring/cc-history/SKILL.md
+++ b/plugins/monitoring/cc-history/SKILL.md
@@ -89,7 +89,7 @@ argument-hint: '[--all] [--yesterday|--today] [--project <path>] [--ticktick] [-
 
 脚本绝对路径：
 ```
-/Users/jiashengwang/jacky-github/jacky-skills/plugins/monitoring/cc-history/scripts/cc-history.py
+~/jacky-github/jacky-skills/plugins/monitoring/cc-history/scripts/cc-history.py
 ```
 
 ```bash

--- a/plugins/obsidian-tools/.claude-plugin/plugin.json
+++ b/plugins/obsidian-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-tools",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Obsidian 工具集 - 笔记同步、知识库管理",
   "author": {
     "name": "Jacky Wang",

--- a/plugins/obsidian-tools/ob-collect/SKILL.md
+++ b/plugins/obsidian-tools/ob-collect/SKILL.md
@@ -140,7 +140,7 @@ web-search 负责"怎么拿"，ob-collect 负责"放哪儿"。raw/ 归档目录�
 >
 > **作者名缺失时**：用平台账号名或频道名；仍无法确定时用 `raw/videos/未知作者/`，不要散落到顶层。
 
-> `{A2S_DIR}` 为 audio-to-subtitle skill 所在目录：`/Users/jiashengwang/jacky-github/jacky-skills/plugins/video-processing/skills/audio-to-subtitle`（ASR 回退流程会用到）
+> `{A2S_DIR}` 为 audio-to-subtitle skill 所在目录：`~/jacky-github/jacky-skills/plugins/video-processing/skills/audio-to-subtitle`（ASR 回退流程会用到）
 
 ### 例外清单（绕过 web-search 的口子）
 

--- a/plugins/skills-management/.claude-plugin/plugin.json
+++ b/plugins/skills-management/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skills-management",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Skills 管理工具 - 链接、安装、批量管理",
   "author": {
     "name": "Jacky Wang",

--- a/plugins/skills-management/skills/j-skills/SKILL.md
+++ b/plugins/skills-management/skills/j-skills/SKILL.md
@@ -256,7 +256,7 @@ npm login
 ### Step 3: 发布到 npm
 
 ```bash
-cd /Users/jiashengwang/jacky-github/jacky-skills-package
+cd ~/jacky-github/jacky-skills-package
 npm publish
 ```
 
@@ -311,7 +311,7 @@ npm update -g @wangjs-jacky/j-skills
 npm login
 
 # 2. 进入项目目录并发布
-cd /Users/jiashengwang/jacky-github/jacky-skills-package
+cd ~/jacky-github/jacky-skills-package
 npm publish
 ```
 
@@ -332,6 +332,12 @@ A: 确保使用 `j-skills link` 链接的软链接，而不是直接复制。
 **Q: 如何查看 skill 已安装到哪些环境？**
 A: 使用 `j-skills list --all --json` 查看完整安装信息。
 
+**Q: 删除了某个 skill 后，注册表 / 全局目录里残留了失效（broken）软链怎么清？**
+A: **不要用 `j-skills link --doctor`** —— 它通过交互式确认（clack 提示）修复，在**非 TTY 环境**（SSH heredoc、CI、管道）下会卡死或把选项乱选成 "No"。正确清理顺序：
+1. `j-skills uninstall <name> --global -y` —— 清掉 registry 条目与各环境安装记录（`-y` 跳过确认，可正常非交互执行）。
+2. 再手动删残留的 broken 软链：`rm ~/.claude/skills/<name>` 和 `rm ~/.j-skills/linked/<name>`。
+   > 注意：`uninstall` 不会删除「指向已删除源路径」的 broken 软链，所以第 2 步必须手动补。删前可用 `[ -L "$p" ] && [ ! -e "$p" ]` 确认确实是 broken 软链再 `rm`，避免误删有效链接。
+
 **Q: 支持哪些 agent？**
 A: 运行 `j-skills list --help` 查看完整列表，或参考官方文档。
 
@@ -350,14 +356,14 @@ A: 需要先执行 `npm login` 登录 npm 账号。
 |------|------|------|
 | 1️⃣ 登录 npm | `npm login` | 只需执行一次 |
 | 2️⃣ 更新版本 | 编辑 `package.json` | PATCH/MINOR/MAJOR |
-| 3️⃣ 发布 | `cd /Users/jiashengwang/jacky-github/jacky-skills-package && npm publish` | 发布到 npm |
+| 3️⃣ 发布 | `cd ~/jacky-github/jacky-skills-package && npm publish` | 发布到 npm |
 | 4️⃣ 更新本地 | `npm update -g @wangjs-jacky/j-skills` | 更新全局安装 |
 
 ### 快速命令
 
 ```bash
 # 一键发布流程
-cd /Users/jiashengwang/jacky-github/jacky-skills-package
+cd ~/jacky-github/jacky-skills-package
 npm login  # 如果已登录可跳过
 npm publish
 npm update -g @wangjs-jacky/j-skills

--- a/skills/pencil-opencli-workflow/SKILL.md
+++ b/skills/pencil-opencli-workflow/SKILL.md
@@ -49,7 +49,7 @@ codex mcp list
 同时检查 server 二进制是否存在：
 
 ```bash
-ls -la /Users/jiashengwang/.pencil/mcp/cursor/out/mcp-server-darwin-arm64
+ls -la ~/.pencil/mcp/cursor/out/mcp-server-darwin-arm64
 ```
 
 如果任一失败，提示用户先完成 Pencil 安装与 MCP 配置，再继续使用 `generate`。


### PR DESCRIPTION
## 背景

把 jacky-skills 同步到 Mac mini 后发现：多个 skill 的 SKILL.md / 脚本里硬编码了 `/Users/jiashengwang/` 绝对路径，在其他机器（mini 用户为 `jacky`）/其他用户下会指向不存在的路径，导致 skill 找错文件。本 PR 统一改成可移植写法。

## 改动

### 1. 路径可移植化（消除全部 12 个文件里的 `/Users/jiashengwang/`）
- **文档 / 命令类** → `~/`：CLAUDE.md、j-skills、repo-study、learn-repo、ob-collect、cc-history、todo/setup-guide、pencil-opencli-workflow、docs 部署记录、archived/multi-agent
- **脚本类** → 真·可移植：
  - `repo-study-sync-ob.sh`：`OB_VAULT` / `STUDY_BASE` 改 `${VAR:-$HOME/...}`（默认值 + 支持 env 覆盖）
  - `todo/tests/verify.sh`：`SKILL_DIR` 用 `${BASH_SOURCE}` 自定位推导，彻底不依赖绝对路径
- **刻意避开 `${CLAUDE_PLUGIN_ROOT}`**：部分 cc-sub/reclaude 环境不展开该变量，统一用 `~/` 更稳

### 2. j-skills SKILL.md 新增常见问题
- 删除 skill 后清理 broken 软链：走 `j-skills uninstall <name> --global -y` + 手动 `rm`，**不要用交互式 `--doctor`**（非 TTY 环境下会卡死/乱选）

### 3. 版本号（PATCH，按项目规则）
| plugin | 版本 |
|--------|------|
| skills-management | 1.0.1 → 1.0.2 |
| learning-tools | 2.3.0 → 2.3.1 |
| obsidian-tools | 2.12.0 → 2.12.1 |
| monitoring | 2.5.4 → 2.5.5 |
| dev-tools | 2.5.0 → 2.5.1 |

## 验证
- ✅ 仓库内已无 `/Users/jiashengwang/` 残留（私有 `*.local.md` 不受影响）
- ✅ 两个改动脚本 `bash -n` 语法通过
- ✅ `verify.sh` 的 `SKILL_DIR` 自定位解析正确